### PR TITLE
Purge old DELETEs during live compaction

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -195,6 +195,12 @@ object SiriusConfiguration {
   final val COMPACTION_SCHEDULE_MINS = "sirius.log.compaction-schedule-mins"
 
   /**
+   * The maximum age for a Delete in hours that remains after compaction.  Deletes
+   * that are older than this age will be purged during compaction.
+   */
+  final val COMPACTION_MAX_DELETE_AGE_HOURS = "sirius.log.compaction-max-delete-age-hours"
+
+  /**
    * Name of the sirius supervisor, typically we will not change this,
    * but it's here just in case (string)
    */

--- a/src/main/scala/com/comcast/xfinity/sirius/tool/WalTool.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/tool/WalTool.scala
@@ -81,11 +81,23 @@ object WalTool {
     Console.err.println("       Same as key-filter, except the resulting UberStore contains all")
     Console.err.println("       OrderedEvents not matching regexp")
     Console.err.println()
+    Console.err.println("   key-filter-deletes-not-older-then <earliestMillis> <inWalDir> <outWalDir>")
+    Console.err.println("       Write all OrderedEvents in UberStore to a new UberStore in outWalDir ")
+    Console.err.println("       while filtering Deletes that are older than the specified timestamp ")
+    Console.err.println()
+    Console.err.println("   key-filter-puts-not-older-than <regexp> <earliestMillis> <inWalDir> <outWalDir>")
+    Console.err.println("       Write all OrderedEvents in UberStore in inWalDir to a new UberStore in outWalDir")
+    Console.err.println("       while filtering Puts that match the regexp and are older than the specified timestamp")
+    Console.err.println()
     Console.err.println("   key-list <inWalDir> <outFile>")
     Console.err.println("       Write all keys from wal in outFile")
     Console.err.println()
     Console.err.println("   key-list-filter <regexp> <inWalDir> <outFile>")
     Console.err.println("       write all keys that match regexp to outFile")
+    Console.err.println()
+    Console.err.println("   key-list-filter-puts-older-than <regexp> <earliestMillis> <inWalDir> <outFile>")
+    Console.err.println("       Write all Put keys that match regexp and are older than the specified timestamp")
+    Console.err.println("       to outFile")
     Console.err.println()
     Console.err.println("   replay <inWalDir> <host> <concurrency>")
     Console.err.println("       For each OrderedEvent will issue an http request")
@@ -131,6 +143,14 @@ object WalTool {
         val filterFun: OrderedEvent => Boolean = keyMatch(regexp, _)
         filter(inWal, outWal, filterFun)
 
+      case Array("key-filter-deletes-not-older-than", earlistTimestamp, inWal, outFile) =>
+        filterDeletesOlderThan(inWal, outFile, earlistTimestamp.toLong)
+
+      case Array("key-filter-puts-not-older-than", regexpStr, earliestTimestamp, inWal, outWal) =>
+        val regexp = regexpStr.r
+        val filterFun: OrderedEvent => Boolean = !keyMatchPutsOlderThan(regexp, earliestTimestamp.toLong, _)
+        filter(inWal, outWal, filterFun)
+
       case Array("key-filter-not", regexpStr, inWal, outWal) =>
         val regexp = regexpStr.r
         val filterFun: OrderedEvent => Boolean = !keyMatch(regexp, _)
@@ -142,6 +162,11 @@ object WalTool {
       case Array("key-list-filter", regexpStr, inWal, outFile) =>
         val regexp = regexpStr.r
         val filterFun: OrderedEvent => Boolean = keyMatch(regexp, _)
+        keyListFilter(inWal, outFile, filterFun)
+
+      case Array("key-list-filter-puts-older-than", regexpStr, earliestTimestamp, inWal, outFile) =>
+        val regexp = regexpStr.r
+        val filterFun: OrderedEvent => Boolean = keyMatchPutsOlderThan(regexp, earliestTimestamp.toLong, _)
         keyListFilter(inWal, outFile, filterFun)
 
       case Array("replay", inWal, host, concurrency) =>
@@ -275,6 +300,19 @@ object WalTool {
     case _ => false
   }
 
+  /**
+   * Does the key match r and is a Put and is older than the specified timestamp
+   * @param r Regexp to match
+   * @param earliestTimestamp timestamp to filter Puts if older than.
+   * @param evt OrderedEvent to check
+   */
+  private def keyMatchPutsOlderThan(r: Regex, earliestTimestamp: Long, evt: OrderedEvent): Boolean = {
+    evt match {
+      case OrderedEvent(_, timestamp, Put(key, _)) => (r.findFirstIn(key) != None) && (timestamp < earliestTimestamp)
+      case _ => false
+    }
+  }
+
   private def keyList(inWal:String, outFile:String){
     val wal: SiriusLog = siriusLog(inWal)
     val keySet = Set[WrappedArray[Byte]]()
@@ -299,7 +337,7 @@ object WalTool {
     val wal  = siriusLog(inWal)
     val keySet = scala.collection.mutable.Set[WrappedArray[Byte]]()
     wal.foreach( _ match {
-      case (evt: OrderedEvent) if pred(evt) => System.out.println("Matched");evt.request match {
+      case (evt: OrderedEvent) if pred(evt) => evt.request match {
         case (put:Put) => keySet += WrappedArray.make(put.key.getBytes)
         case (delete: Delete) => keySet -= WrappedArray.make(delete.key.getBytes)
       }
@@ -313,6 +351,42 @@ object WalTool {
       })
     }finally{
       out.close()
+    }
+  }
+
+  /**
+   * Write all entries from UberStore specified by inUberDir to outUberDir (which should not exist)
+   * while filtering deletes that are older the specified timestamp.
+   *
+   * @param earliestTimestamp the earliest timestamp
+   * @param inUberDir input UberStore directory
+   * @param outUberDir output UberStore directory
+   */
+  private def filterDeletesOlderThan(inUberDir: String, outUberDir: String, earliestTimestamp: Long) {
+    createFreshDir(outUberDir)
+
+    val inWal = siriusLog(inUberDir)
+
+    val outWal = inUberDir match {
+      case (dir : String) if UberTool.isLegacy(dir) => UberStore(outUberDir)
+      case (dir: String) if UberTool.isSegmented(dir) =>
+        SegmentedUberStore.init(outUberDir)
+        SegmentedUberStore(outUberDir)
+      case _ => throw new IllegalArgumentException(inUberDir + " does not appear to be a valid Uberstore")
+    }
+
+    inWal.foreach {
+      case evt if filterDeletesOlderThan(evt, earliestTimestamp) != None => outWal.writeEntry(evt)
+      case _ =>
+    }
+  }
+
+  private def filterDeletesOlderThan(evt: OrderedEvent, earliestTimestamp: Long): Option[OrderedEvent] = {
+    val request = evt.request
+    request match {
+      case (put: Put) => Some(evt)
+      case (delete: Delete) if evt.timestamp >= earliestTimestamp => Some(evt)
+      case _ => None
     }
   }
 

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -15,14 +15,27 @@
  */
 package com.comcast.xfinity.sirius.uberstore.segmented
 
+import com.comcast.xfinity.sirius.api.SiriusConfiguration
+import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
+
 import scalax.file.Path
 import java.io.File
 import annotation.tailrec
 
 object SegmentedCompactor {
-
   val COMPACTING_SUFFIX = ".compacting"
   val TEMP_SUFFIX = ".temp"
+
+  def apply(siriusConfig: SiriusConfiguration) : SegmentedCompactor = {
+
+    val maxDeleteAgeHours = siriusConfig.getProp(SiriusConfiguration.COMPACTION_MAX_DELETE_AGE_HOURS, Integer.MAX_VALUE) // a really long time by default
+    val maxDeleteAgeMillis = 60L * 60 * 1000 * maxDeleteAgeHours
+
+    new SegmentedCompactor(maxDeleteAgeMillis)
+  }
+}
+
+class SegmentedCompactor(maxDeleteAgeMillis: Long) {
 
   /**
    * Replaces one Segment file with another, removing the original.
@@ -40,7 +53,7 @@ object SegmentedCompactor {
     val originalPath = Path.fromString(original.location.getAbsolutePath)
     val replacementPath = Path.fromString(replacement)
     val tempPath = Path.fromString(
-      new File(original.location.getParent, original.location.getName + TEMP_SUFFIX).getAbsolutePath
+      new File(original.location.getParent, original.location.getName + SegmentedCompactor.TEMP_SUFFIX).getAbsolutePath
     )
 
     originalPath.moveTo(tempPath)
@@ -81,7 +94,7 @@ object SegmentedCompactor {
     val keys = toCompact.keys
     segments.foldLeft(Map[Segment, String]())(
       (map, toCompact) => {
-        val compactInto = Segment(toCompact.location.getParentFile, toCompact.name + COMPACTING_SUFFIX)
+        val compactInto = Segment(toCompact.location.getParentFile, toCompact.name + SegmentedCompactor.COMPACTING_SUFFIX)
         compactSegment(keys, toCompact, compactInto)
 
         compactInto.setApplied(toCompact.isApplied)
@@ -92,17 +105,19 @@ object SegmentedCompactor {
   }
 
   /**
-   * Compact a single Segment, according to the GC keys provided
+   * Compact a single Segment, according to the GC keys provided.  Deletes that are older than the maxDeleteAge
+   * are purged.
    *
    * @param keys keys to gc against
    * @param source source segment, to be GC'ed
    * @param dest destination segment, empty, will be populated
    */
   private def compactSegment(keys: Set[String], source: Segment, dest: Segment) {
-    // XXX if we want to remove old deletes from the log...
-    // val currentTime = System.currentTimeMillis
+    val currentTime = System.currentTimeMillis
+    val earliestDelete = if (maxDeleteAgeMillis > currentTime) 0L else currentTime - maxDeleteAgeMillis
+
     source.foreach {
-      // case OrderedEvent(_, timestamp, Delete(key)) if (currentTime - timestamp) > MAX_DELETE_AGE => // nothing
+      case OrderedEvent(_, timestamp, Delete(key)) if timestamp < earliestDelete => // nothing
       case event if !keys.contains(event.request.key) => dest.writeEntry(event)
       case _ => // this event is overridden by some future event: garbage collect it.
     }
@@ -116,7 +131,7 @@ object SegmentedCompactor {
    * @return optional tuple2 of mergeable segments
    */
   @tailrec
-  def findNextMergeableSegments(segments: List[Segment], isMergeable: (Segment, Segment) => Boolean): Option[(Segment, Segment)] = {
+  final def findNextMergeableSegments(segments: List[Segment], isMergeable: (Segment, Segment) => Boolean): Option[(Segment, Segment)] = {
     segments.take(2) match {
       case list if list.size < 2 => None
       case list if isMergeable(list(0), list(1)) => Some(list(0), list(1))
@@ -152,3 +167,4 @@ object SegmentedCompactor {
   }
 
 }
+

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
@@ -18,6 +18,8 @@ package com.comcast.xfinity.sirius.uberstore.segmented
 
 import com.comcast.xfinity.sirius.NiceTest
 import java.io.File
+import com.comcast.xfinity.sirius.api.SiriusConfiguration
+
 import scalax.file.Path
 import org.scalatest.BeforeAndAfterAll
 import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
@@ -35,9 +37,9 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     dir
   }
 
-  def writeEvents(segment: Segment, events: List[Long]) {
+  def writeEvents(segment: Segment, events: List[Long], timestamp: Long = 0L) {
     for (i <- events) {
-      segment.writeEntry(OrderedEvent(i, 0L, Delete(i.toString)))
+      segment.writeEntry(OrderedEvent(i, timestamp, Delete(i.toString)))
     }
   }
 
@@ -50,6 +52,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     segment.foldLeft(List[String]())((acc, event) => event.request.key :: acc).reverse.mkString(" ")
 
   var dir: File = _
+
+  val siriusConfig = new SiriusConfiguration()
 
   before {
     dir = createTempDir
@@ -70,7 +74,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       val expected = replacement.foldLeft(List[Long]())(foldFun)
 
-      val result = SegmentedCompactor.replace(original, replacement.location.getAbsolutePath)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val result = segmentedCompactor.replace(original, replacement.location.getAbsolutePath)
 
       assert(original.location.getAbsolutePath === result.location.getAbsolutePath)
       assert(expected === result.foldLeft(List[Long]())(foldFun))
@@ -85,7 +90,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       val expected = List[Long]()
 
-      val result = SegmentedCompactor.replace(original, replacement.location.getAbsolutePath)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val result = segmentedCompactor.replace(original, replacement.location.getAbsolutePath)
 
       assert(original.location.getAbsolutePath === result.location.getAbsolutePath)
       assert(expected === result.foldLeft(List[Long]())(foldFun))
@@ -95,7 +101,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
   describe("findCompactableSegments") {
     it("should return an empty List if no segments are provided") {
       val list = List[Segment]()
-      assert(List() === SegmentedCompactor.findCompactableSegments(list))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(List() === segmentedCompactor.findCompactableSegments(list))
     }
 
     it("should return an empty List if all segments have been applied") {
@@ -104,7 +111,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       doReturn(true).when(mockSegment).isApplied
 
-      assert(List() === SegmentedCompactor.findCompactableSegments(list))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(List() === segmentedCompactor.findCompactableSegments(list))
     }
 
     it("should return only the segments that have not been applied if there are some") {
@@ -115,7 +123,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       doReturn(true).when(appliedSegment).isApplied
       doReturn(false).when(notAppliedSegment).isApplied
 
-      assert(List(notAppliedSegment) === SegmentedCompactor.findCompactableSegments(list))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(List(notAppliedSegment) === segmentedCompactor.findCompactableSegments(list))
     }
   }
 
@@ -127,7 +136,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = false)
-      val compactionMap = SegmentedCompactor.compactAgainst(second, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       assert(false === makeSegment(compactionMap(first)).isApplied)
     }
 
@@ -138,7 +148,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = true)
-      val compactionMap = SegmentedCompactor.compactAgainst(second, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       assert(true === makeSegment(compactionMap(first)).isApplied)
     }
 
@@ -150,7 +161,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(first, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(first, segments)
 
       assert(None == compactionMap.get(first))
       assert(None == compactionMap.get(second))
@@ -165,7 +177,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(second, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(second, segments)
 
       assert(None != compactionMap.get(first))
       assert(None == compactionMap.get(second))
@@ -180,7 +193,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(third, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(third, segments)
 
       assert(None != compactionMap.get(first))
       assert(None != compactionMap.get(second))
@@ -195,7 +209,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(third, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(third, segments)
 
       assert(None != compactionMap.get(first))
       assert(None != compactionMap.get(second))
@@ -210,7 +225,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(3L, 4L, 5L, 6L))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(second, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       val compacted = makeSegment(compactionMap(first))
 
       assert("1 2" === listEvents(compacted))
@@ -224,7 +240,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(1L, 2L, 3L, 4L))
 
-      val compactionMap = SegmentedCompactor.compactAgainst(second, segments)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       val compacted = makeSegment(compactionMap(first))
 
       assert(List(first) === compactionMap.keys.toList)
@@ -232,11 +249,34 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
   }
 
+  it("should remove all delete events in appropriate segments that are older than COMPACTION_MAX_DELETE_AGE_HOURS") {
+    val first = Segment(dir, "1")
+    val second = Segment(dir, "2")
+    val segments = List(first, second)
+
+    val now = System.currentTimeMillis()
+    val twoHoursAgo = now - 2L * 60 * 60 * 1000
+
+    writeEvents(first, List(1L), twoHoursAgo) // This one should be compacted out due to age.
+    writeEvents(first, List(2L, 3L, 4L), now)
+    writeEvents(second, List(3L, 4L, 5L, 6L), now)
+
+    val siriusConfigWithMaxAge = new SiriusConfiguration()
+    siriusConfigWithMaxAge.setProp(SiriusConfiguration.COMPACTION_MAX_DELETE_AGE_HOURS, 1)
+    val segmentedCompactor = SegmentedCompactor(siriusConfigWithMaxAge)
+    val compactionMap = segmentedCompactor.compactAgainst(second, segments)
+
+    val compacted = makeSegment(compactionMap(first))
+
+    assert("2" === listEvents(compacted))
+  }
+
   describe("findNextMergeableSegments") {
     it("should do nothing if the input is of size 0 or 1") {
       val isMergeable = (left: Segment, right: Segment) => true
-      assert(None === SegmentedCompactor.findNextMergeableSegments(List(), isMergeable))
-      assert(None === SegmentedCompactor.findNextMergeableSegments(List(Segment(dir, "1")), isMergeable))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(None === segmentedCompactor.findNextMergeableSegments(List(), isMergeable))
+      assert(None === segmentedCompactor.findNextMergeableSegments(List(Segment(dir, "1")), isMergeable))
     }
 
     it("should return the first two elements if the return true for the isMergeable predicate") {
@@ -244,32 +284,37 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
       val segments = List(one, two, three)
 
-      assert(Some(one, two) === SegmentedCompactor.findNextMergeableSegments(segments, isMergeable))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(Some(one, two) === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
     it("should return None if there are no mergeable elements in the list") {
       val isMergeable = (left: Segment, right: Segment) => false
       val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
       val segments = List(one, two, three)
 
-      assert(None === SegmentedCompactor.findNextMergeableSegments(segments, isMergeable))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(None === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
     it("should return the first mergeable elements in the list if there are any") {
       val isMergeable = (left: Segment, right: Segment) => left.name == "2" && right.name == "3"
       val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
       val segments = List(one, two, three)
 
-      assert(Some(two, three) === SegmentedCompactor.findNextMergeableSegments(segments, isMergeable))
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      assert(Some(two, three) === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
   }
   describe("delete") {
     it("should close the input segment") {
       val segment = Segment(dir, "1")
-      SegmentedCompactor.delete(segment)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.delete(segment)
       assert(true === segment.isClosed)
     }
     it("should remove the location of segment from the filesystem") {
       val segment = Segment(dir, "1")
-      SegmentedCompactor.delete(segment)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.delete(segment)
       assert(false === segment.location.exists())
     }
   }
@@ -279,7 +324,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       val target = new File(dir, "1-2.merged")
 
       assert(false === target.exists())
-      SegmentedCompactor.mergeSegments(left, right, target)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.mergeSegments(left, right, target)
       assert(true === target.exists())
     }
     it("should write all of the elements from left and right into target, in order") {
@@ -288,7 +334,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       writeEvents(right, List(4L, 5L, 6L))
       val target = new File(dir, "1-2.merged")
 
-      SegmentedCompactor.mergeSegments(left, right, target)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.mergeSegments(left, right, target)
 
       assert("1 2 3 4 5 6" === listEvents(Segment(target)))
     }
@@ -298,7 +345,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       right.setApplied(applied = true)
       val target = new File(dir, "1-2.merged")
 
-      SegmentedCompactor.mergeSegments(left, right, target)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.mergeSegments(left, right, target)
 
       assert(true === Segment(target).isApplied)
     }
@@ -308,7 +356,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       right.setApplied(applied = true)
       val target = new File(dir, "1-2.merged")
 
-      SegmentedCompactor.mergeSegments(left, right, target)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.mergeSegments(left, right, target)
 
       assert(false === Segment(target).isApplied)
     }

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -148,7 +148,9 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should split after the specified number of events have been written") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       assert("1" === underTest.liveDir.name)
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
@@ -195,7 +197,9 @@ class SegmentedUberStoreTest extends NiceTest {
 
   describe("compact") {
     it ("should perform a do-nothing compact of a single Segment, if |readOnlyDirs| == 1") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       underTest.compactAll()
@@ -206,7 +210,9 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should perform a real compact of Segment 1 if Segment 2 is read-only") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       writeUberStoreEvents(underTest, Range.inclusive(6, 15).toList)


### PR DESCRIPTION
This change is to address Issue 112, 'Old deletes need to be purged
during Compaction'.

It adds the ability to specify a
sirius.log.compaction-max-delete-age-hours configuration property to
cause old Delete events to be purged during live compaction.

The configuration property defaults to a very large value, so by default
Delete events will not be purged.

It also adds an option to WalTool to purge old Deletes, along with
other options for old PUTs.
